### PR TITLE
fix(repl): add `getMarket` in `USUMMarketFactory`

### DIFF
--- a/contracts/core/USUMMarketFactory.sol
+++ b/contracts/core/USUMMarketFactory.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {IUSUMMarketFactory} from "@usum/core/interfaces/IUSUMMarketFactory.sol";
+import {IUSUMMarket} from "@usum/core/interfaces/IUSUMMarket.sol";
 import {IMarketDeployer} from "@usum/core/interfaces/factory/IMarketDeployer.sol";
 import {IUSUMVault} from "@usum/core/interfaces/IUSUMVault.sol";
 import {MarketDeployer, MarketDeployerLib, Parameters} from "@usum/core/external/deployer/MarketDeployer.sol";
@@ -94,6 +95,21 @@ contract USUMMarketFactory is IUSUMMarketFactory {
         address settlementToken
     ) external view override returns (address[] memory) {
         return _marketsBySettlementToken[settlementToken];
+    }
+
+    function getMarket(
+        address oracleProvider,
+        address settlementToken
+    ) external view override returns (address) {
+        if(!_registered[oracleProvider][settlementToken]) return address(0);
+
+        address[] memory markets = _marketsBySettlementToken[settlementToken];
+        for (uint i=0; i < markets.length; i++) {
+            if (address(IUSUMMarket(markets[i]).oracleProvider()) == oracleProvider) {
+                return markets[i];
+            }
+        }
+        return address(0);
     }
 
     function isRegisteredMarket(

--- a/contracts/core/interfaces/IUSUMMarketFactory.sol
+++ b/contracts/core/interfaces/IUSUMMarketFactory.sol
@@ -48,6 +48,9 @@ interface IUSUMMarketFactory is
         address settlementToken
     ) external view returns (address[] memory);
 
+    function getMarket(address oracleProvider,
+        address settlementToken) external view returns (address);
+
     function createMarket(
         address oracleProvider,
         address settlementToken

--- a/deploy/3_deploy_mockup.ts
+++ b/deploy/3_deploy_mockup.ts
@@ -50,6 +50,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     { from: deployer }
   )
   console.log(chalk.yellow("✨ Create Market"))
+  console.log(chalk.yellow("✨ Done!"))
 }
 
 export default func

--- a/repl/ReplWallet.ts
+++ b/repl/ReplWallet.ts
@@ -108,6 +108,7 @@ export class ReplWallet {
       await this.AccountFactory.createAccount()
       accountAddress = await this.AccountFactory["getAccount()"]()
     }
+    console.log(`crete Account, signer: ${accountAddress}, ${this.signer.address}`)
     this.Account = IAccount__factory.connect(accountAddress, this.signer)
   }
 

--- a/repl/index.ts
+++ b/repl/index.ts
@@ -12,6 +12,7 @@ import {
   USUMLiquidatorMock__factory,
 } from "../typechain-types"
 import { ReplWallet } from "./ReplWallet"
+import "./type-extensions"
 
 const SIGNERS = [
   "alice",
@@ -115,9 +116,10 @@ extendEnvironment((hre) => {
       marketFactoryAddress,
       deployer
     )
-    const [marketAddress] = await marketFactory.getMarket(
+
+    const marketAddress = await marketFactory.getMarket(
       oracleProvider.address,
-      USDC_ARBITRUM_GOERLI.address
+      USDC_ARBITRUM_GOERLI.address,
     )
     const { address: liquidatorAddress } = await deployments.get(
       "USUMLiquidatorMock"
@@ -126,6 +128,7 @@ extendEnvironment((hre) => {
       liquidatorAddress,
       gelato
     )
+    
     for (const signer of SIGNERS) {
       const w: ReplWallet = hre.w[signer]
       const positionIds = await w.Account.getPositionIds(marketAddress)

--- a/repl/type-extensions.ts
+++ b/repl/type-extensions.ts
@@ -1,0 +1,12 @@
+// If your plugin extends types from another plugin, you should import the plugin here.
+
+// To extend one of Hardhat's types, you need to import the module where it has been defined, and redeclare it.
+import "hardhat/types/runtime"
+
+declare module "hardhat/types/runtime" {
+  interface HardhatRuntimeEnvironment {
+    w: object
+    initialize?: () => Promise<void>
+    updatePrice?: (number) => Promise<void>
+  }
+}


### PR DESCRIPTION
Fixes: #105
add `getMarket(oracleProvider, settlementToken)` view함수 추가 했습니다. @daniel-fi 


@austin-builds @jaycho-46 
백그라운드 띄우고
```sh
> yarn chain &
```

```sh
❯ yarn repl                                                                                                                                                                                                                                                      ─╯
yarn run v1.22.19
warning package.json: No license field
$ hardhat console --network anvil --config hardhat.repl.config.ts --no-compile
Welcome to Node.js v18.14.2.
Type ".help" for more information.
> await initialize()
crete Account, signer: 0xBFF22091be481B41C8CA49862653aBA216bAc041, 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC
crete Account, signer: 0xD99e117099158fd3191d1688975618FC11A4cdb5, 0x90F79bf6EB2c4f870365E785982E1f101E93b906
undefined
> await updatePrice(100)
undefined
```