### PR TITLE
fix(sdk): include `IERC20Meta` in SDK

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -104,6 +104,7 @@ const config: HardhatUserConfig = {
       "USUMRouter",
       "AggregatorV3Interface",
       "**/IERC20.sol/*",
+      "**/IERC20Metadata.sol/*",
       "**/IERC1155.sol/*",
     ],
     excludes: ["**/*Lib", "**/*Mock"],


### PR DESCRIPTION
Fixes #130