### PR TITLE
chore: prevent from writing `.nojekyll`

### DIFF
--- a/.github/workflows/release-publish-sdk.yml
+++ b/.github/workflows/release-publish-sdk.yml
@@ -63,3 +63,4 @@ jobs:
           external_repository: chromatic-protocol/sdk-typechain
           destination_dir: src.ts
           publish_branch: develop
+          enable_jekyll: true


### PR DESCRIPTION
Fixes #186