### PR TITLE
ci: use forked action of `github-app-token`

### DIFF
--- a/.github/workflows/release-publish-sdk.yml
+++ b/.github/workflows/release-publish-sdk.yml
@@ -56,7 +56,7 @@ jobs:
           path: sdk
           ssh-key: ${{ secrets.SSH_SDK_TYPECHAIN }}
       - run: cp -r package-build/src.ts/* sdk/src/gen/
-      - uses: tibdex/github-app-token@v1
+      - uses: chromatic-protocol/action-github-app-token@v1
         id: generate-token
         with:
           app_id: ${{ secrets.PR_ACTION_APP_ID }}


### PR DESCRIPTION
Fixes #223