### PR TITLE
ci: split PR action to `docs` from publishing

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,49 @@
+name: publish docs
+
+on:
+  pull_request:
+    types:
+      - closed
+    paths:
+      - contracts/**
+      - docs/**
+      - .github/workflows/publish-docs.yml
+permissions:
+  contents: write
+
+jobs:
+  Docs:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+    steps:
+      - uses: chromatic-protocol/action-setup-foundry-yarn@v1
+        with:
+          scope: '@chromatic-protocol'
+          ignore-scripts: false
+          node-auth-token: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: chromatic-protocol/action-github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.PR_ACTION_APP_ID }}
+          private_key: ${{ secrets.PR_ACTION_PRIVATE }}
+      # make a PR to chromatic-protocol/docs
+      - uses: actions/checkout@v3
+        with:
+          repository: chromatic-protocol/docs
+          ref: main
+          path: docs-repo
+          token: ${{ steps.generate-token.outputs.token }}
+      - run: |
+          yarn docs
+          cp -r docs/out/* docs-repo/docs/contracts/reference/
+      - name: pull-request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          base: main
+          branch: docs/contracts
+          path: docs-repo
+          add-paths: docs/contracts/reference/**
+          token: ${{ steps.generate-token.outputs.token }}
+          commit-message: ${{ github.event.pull_request.title }}

--- a/.github/workflows/release-publish-sdk.yml
+++ b/.github/workflows/release-publish-sdk.yml
@@ -1,7 +1,7 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
-name: release and export source
+name: release and publish sdk
 
 on:
   pull_request:
@@ -45,7 +45,7 @@ jobs:
           release_name: ${{ steps.changelog.outputs.tag }}
           body: ${{ steps.changelog.outputs.clean_changelog }}
           prerelease: true
-  Export:
+  Publish:
     needs: Release
     runs-on: ubuntu-latest
     permissions:
@@ -87,24 +87,5 @@ jobs:
           branch: develop
           path: sdk
           add-paths: src/gen/**
-          token: ${{ steps.generate-token.outputs.token }}
-          commit-message: ${{ github.event.pull_request.title }}
-      # make a PR to chromatic-protocol/docs
-      - uses: actions/checkout@v3
-        with:
-          repository: chromatic-protocol/docs
-          ref: main
-          path: docs-repo
-          token: ${{ steps.generate-token.outputs.token }}
-      - run: |
-          yarn docs
-          cp -r docs/out/* docs-repo/docs/contracts/reference/
-      - name: pull-request
-        uses: peter-evans/create-pull-request@v5
-        with:
-          base: main
-          branch: docs/contracts
-          path: docs-repo
-          add-paths: docs/contracts/reference/**
           token: ${{ steps.generate-token.outputs.token }}
           commit-message: ${{ github.event.pull_request.title }}

--- a/docs/docgen.config.ts
+++ b/docs/docgen.config.ts
@@ -1,0 +1,8 @@
+import type { HardhatUserConfig } from 'hardhat/config'
+
+export default {
+  pages: 'files',
+  templates: 'docs/templates',
+  exclude: ['mocks'],
+  outputDir: 'docs/out'
+} as HardhatUserConfig['docgen']

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,9 +5,10 @@ import '@nomiclabs/hardhat-ethers'
 import * as dotenv from 'dotenv'
 import 'hardhat-contract-sizer'
 import 'hardhat-deploy'
-import { HardhatUserConfig } from 'hardhat/config'
+import type { HardhatUserConfig } from 'hardhat/config'
 import 'solidity-docgen'
 import 'tsconfig-paths/register'
+import docgenConfig from './docs/docgen.config'
 
 dotenv.config()
 
@@ -129,12 +130,7 @@ const config: HardhatUserConfig = {
     excludesFromDeployed: ['KeeperFeePayer', '*Lib', '*Mock'],
     excludeBytecode: true
   },
-  docgen: {
-    pages: 'files',
-    templates: 'docs/templates',
-    exclude: ['mocks'],
-    outputDir: 'docs/out'
-  }
+  docgen: docgenConfig
 }
 
 export default config


### PR DESCRIPTION
Fixes #280