### PR TITLE
ci: remove folders only in `docs/reference`

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -38,6 +38,7 @@ jobs:
       - run: |
           yarn clean
           yarn docs
+          rm -rf docs-repo/docs/contracts/reference/*/
           cp -r docs/out/* docs-repo/docs/contracts/reference/
       - name: pull-request
         uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
fixes: #286 