### PR TITLE
chore: set `evm_version` to `shanghai`

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,3 +4,4 @@ out = 'out'
 libs = ['node_modules', 'lib']
 test = 'test/forge'
 cache_path  = 'cache_forge'
+evm_version = 'shanghai'


### PR DESCRIPTION
Fixes #330