### PR TITLE
Update ChromaticVault.sol

### DIFF
--- a/contracts/core/ChromaticVault.sol
+++ b/contracts/core/ChromaticVault.sol
@@ -75,7 +75,7 @@ contract ChromaticVault is IChromaticVault, ReentrancyGuard {
      *      Throws an `OnlyAccessableByMarket` error if the caller is not a registered market.
      */
     modifier onlyMarket() {
-        if (!factory.isRegisteredMarket(msg.sender)) revert OnlyAccessableByMarket();
+        _checkMarket();
         _;
     }
     /**
@@ -97,6 +97,16 @@ contract ChromaticVault is IChromaticVault, ReentrancyGuard {
         earningDistributor = _earningDistributor;
         keeperFeePayer = IKeeperFeePayer(factory.keeperFeePayer());
     }
+
+    // Internal Functions
+    
+    /**
+    * @dev This function can only be called by the modifier onlyMarket.
+    */
+    function _checkMarket() internal view {
+        if (!factory.isRegisteredMarket(msg.sender)) revert OnlyAccessableByMarket();
+    }
+
 
     // implement IVault
 


### PR DESCRIPTION
Same as #606 

Enhanced the modifier `onlyMarket` cuz it appeared kind of 6 times, and rest of the modifier weren't used as much..

Btw, there's a thing I noticed inside this contract, `using Math as uint256`. Usually, there's no need to use this library if our pragma solidity versions are greater or equal to ^0.8. Solidity already included underflow and overflow checks in it's new versions. Maybe you be having some different purpose on using this Math library..Just let me know