### PR TITLE
add custom error selectors to docs

### DIFF
--- a/docs/errors-templates/helpers.ts
+++ b/docs/errors-templates/helpers.ts
@@ -20,3 +20,21 @@ export function formatVariable(v: VariableDeclaration): string {
 export function getConstantValue(v: VariableDeclaration): string {
   return (v as any).value?.value
 }
+
+export function dedupeErrors(
+  items: (DocItemWithContext & { errors: any })[]
+): { errorSelector: string; signature: string }[] {
+  const allErrors: { errorSelector: string; signature: string }[] = []
+  items.forEach((item) => {
+    item.errors?.forEach((err: any) => {
+      if (allErrors.filter((allErr) => allErr.errorSelector === err.errorSelector).length === 0) {
+        allErrors.push({
+          errorSelector: err.errorSelector,
+          signature: err.signature.replace('error ', '')
+        })
+      }
+    })
+  })
+
+  return allErrors
+}

--- a/docs/errors-templates/page.hbs
+++ b/docs/errors-templates/page.hbs
@@ -21,3 +21,10 @@ sidebar_position: 3
 {{/hsection}}
 {{/if}}
 {{/each}}
+
+## Custom Error Selectors
+| Signature | Error name |
+| ---- | ---- |
+{{#each (dedupeErrors items)}}
+|0x{{this.errorSelector}}|{{this.signature}}|
+{{/each}}


### PR DESCRIPTION
Fixes #643

output:

## Custom Error Selectors
| Signature | Error name |
| ---- | ---- |
|0x1353f3f1|OnlyAccessableByMarket()|
|0x808ca14f|OnlyAccessableByDao()|
|0xb209caed|AlreadySetLiquidator()|
|0xb661034d|AlreadySetVault()|
|0x85295cee|AlreadySetKeeperFeePayer()|
|0x19b72bf5|AlreadySetMarketSettlement()|
|0x3c9b5739|NotRegisteredOracleProvider()|
|0x12a5f552|NotRegisteredSettlementToken()|
|0xde70de22|ExistMarket()|
|0x6119ddb9|OnlyAccessableByFactoryOrDao()|
|0x6d0340d7|OnlyAccessableByEarningDistributor()|
|0xad3a8b9e|NotEnoughBalance()|
|0x3244470d|NotEnoughFeePaid()|
|0x0a73bac7|KeeperFeeTransferFailure()|
|0x33017967|InvalidSwapValue()|
|0xc671c2bd|ExistMarketSettlementTask()|
|0x6c7e0fa5|OnlyAccessableByVault()|
|0xf953ee45|ExistMakerEarningDistributionTask()|
|0x3d8ff6d7|ExistMarketEarningDistributionTask()|
|0x5660035a|OnlyAccessableByLiquidator()|
|0x33fceb32|AlreadyClosedPosition()|
|0x22b76217|NotClaimablePosition()|
|0x22313ae9|TooSmallAmount()|
|0xd54b6688|NotClaimableLpReceipt()|
|0xcc93170c|NotWithdrawableLpReceipt()|
|0x35c67ed1|InvalidLpReceiptAction()|
|0xa5bde9fe|InvalidTransferredTokenAmount()|
|0xc47b3480|NotExistLpReceipt()|
|0xc9b05689|TooSmallTakerMargin()|
|0x65f10725|NotEnoughMarginTransferred()|
|0x39218f3b|NotPermitted()|
|0x444f42ff|ExceedMaxAllowableTradingFee()|
|0xa4c6cd8a|ExceedMaxAllowableLeverage()|
|0xd6b3c14c|NotAllowableMakerMargin()|
|0x5690b016|NotExistPosition()|
|0x7a5f85be|ClaimPositionCallbackError()|
|0x192105d7|InitializationFunctionReverted(address _initializationContractAddress, bytes _calldata)|
|0x68e7727f|UnableToSyncError()|
|0x3d8461ae|PriceFeedNotExist()|
|0x52347554|InvalidOracleRound()|
|0x91655201|NotRouter()|
|0x30cd7471|NotOwner()|
|0x0dc149f0|AlreadyInitialized()|
|0xc4bbea69|NotMarket()|
