### PR TITLE
Unused libraries

### DIFF
--- a/contracts/core/interfaces/factory/ISettlementTokenRegistry.sol
+++ b/contracts/core/interfaces/factory/ISettlementTokenRegistry.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {InterestRate} from "@chromatic-protocol/contracts/core/libraries/InterestRate.sol";
 
 /**

--- a/contracts/core/libraries/Position.sol
+++ b/contracts/core/libraries/Position.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0 <0.9.0;
 
-import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
-import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-import {SignedMath} from "@openzeppelin/contracts/utils/math/SignedMath.sol";
+// import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+// import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+// import {SignedMath} from "@openzeppelin/contracts/utils/math/SignedMath.sol";
 import {IOracleProvider} from "@chromatic-protocol/contracts/oracle/interfaces/IOracleProvider.sol";
 import {PositionUtil} from "@chromatic-protocol/contracts/core/libraries/PositionUtil.sol";
 import {LpContext} from "@chromatic-protocol/contracts/core/libraries/LpContext.sol";

--- a/contracts/core/libraries/liquidity/LiquidityBin.sol
+++ b/contracts/core/libraries/liquidity/LiquidityBin.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0 <0.9.0;
 
-import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {SignedMath} from "@openzeppelin/contracts/utils/math/SignedMath.sol";
 import {PendingPosition, ClosingPosition, LiquidityBinValue, PendingLiquidity, ClaimableLiquidity} from "@chromatic-protocol/contracts/core/interfaces/market/Types.sol";
 import {BinLiquidity, BinLiquidityLib} from "@chromatic-protocol/contracts/core/libraries/liquidity/BinLiquidity.sol";
@@ -32,7 +31,6 @@ struct LiquidityBin {
  * @notice Library for managing liquidity bin
  */
 library LiquidityBinLib {
-    using Math for uint256;
     using SignedMath for int256;
     using LiquidityBinLib for LiquidityBin;
     using BinLiquidityLib for BinLiquidity;

--- a/contracts/core/libraries/liquidity/PositionParam.sol
+++ b/contracts/core/libraries/liquidity/PositionParam.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0 <0.9.0;
 
-import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {SignedMath} from "@openzeppelin/contracts/utils/math/SignedMath.sol";
 import {IOracleProvider} from "@chromatic-protocol/contracts/oracle/interfaces/IOracleProvider.sol";
 import {PositionUtil} from "@chromatic-protocol/contracts/core/libraries/PositionUtil.sol";
@@ -16,8 +15,8 @@ import {LpContext} from "@chromatic-protocol/contracts/core/libraries/LpContext.
  * @param makerMargin The margin amount provided by the maker
  * @param openTimestamp The timestamp of the position's open transaction
  * @param closeTimestamp The timestamp of the position's close transaction
- * @param _entryVersionCache Caches the settle oracle version for the position's entry
- * @param _exitVersionCache Caches the settle oracle version for the position's exit
+ * @param _entryVersionCache Caches the settled oracle version for the position's entry
+ * @param _exitVersionCache Caches the settled oracle version for the position's exit
  */
 struct PositionParam {
     uint256 openVersion;
@@ -38,11 +37,10 @@ using PositionParamLib for PositionParam global;
  * @notice Library for manipulating PositionParam struct.
  */
 library PositionParamLib {
-    using Math for uint256;
     using SignedMath for int256;
 
     /**
-     * @notice Returns the settle version for the position's entry.
+     * @notice Returns the settled version for the position's entry.
      * @param self The PositionParam struct.
      * @return uint256 The settle version for the position's entry.
      */
@@ -82,7 +80,7 @@ library PositionParamLib {
     }
 
     /**
-     * @notice Retrieves the settle oracle version for the position's entry.
+     * @notice Retrieves the settled oracle version for the position's entry.
      * @param self The PositionParam struct.
      * @param ctx The LpContext struct.
      * @return OracleVersion The settle oracle version for the position's entry.

--- a/contracts/oracle/PythFeedOracle.sol
+++ b/contracts/oracle/PythFeedOracle.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "./interfaces/IOracleProvider.sol";
 import "@pythnetwork/pyth-sdk-solidity/AbstractPyth.sol";
 import {SignedMath} from "@openzeppelin/contracts/utils/math/SignedMath.sol";

--- a/contracts/periphery/ChromaticLens.sol
+++ b/contracts/periphery/ChromaticLens.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {IOracleProvider} from "@chromatic-protocol/contracts/oracle/interfaces/IOracleProvider.sol";
 import {IChromaticMarket} from "@chromatic-protocol/contracts/core/interfaces/IChromaticMarket.sol";
 import {PendingLiquidity, ClaimableLiquidity, LiquidityBinStatus} from "@chromatic-protocol/contracts/core/interfaces/market/Types.sol";
@@ -17,7 +16,6 @@ import {IChromaticRouter} from "@chromatic-protocol/contracts/periphery/interfac
  * @dev A contract that provides utility functions for interacting with Chromatic markets.
  */
 contract ChromaticLens {
-    using Math for uint256;
 
     struct CLBBalance {
         uint256 tokenId;
@@ -35,7 +33,7 @@ contract ChromaticLens {
     /**
      * @dev Retrieves the OracleVersion for the specified oracle version in the given Chromatic market.
      * @param market The address of the Chromatic market contract.
-     * @param version An oracle versions.
+     * @param version An oracle version.
      * @return oracleVersion The OracleVersion for the specified oracle version.
      */
     function oracleVersion(


### PR DESCRIPTION
There were two kind of imports -> `Math` and `SafeCast` which were imported within the files but never used. So this PR aims to either removing those imports or commenting them out.
Refers #649 